### PR TITLE
Fix tradier history provider

### DIFF
--- a/QuantConnect.TradierBrokerage.Tests/TradierBrokerageTests.cs
+++ b/QuantConnect.TradierBrokerage.Tests/TradierBrokerageTests.cs
@@ -25,6 +25,7 @@ using QuantConnect.Lean.Engine.DataFeeds;
 using QuantConnect.Logging;
 using QuantConnect.Orders;
 using QuantConnect.Securities;
+using QuantConnect.Tests.Engine.DataFeeds;
 
 namespace QuantConnect.Tests.Brokerages.Tradier
 {
@@ -76,7 +77,7 @@ namespace QuantConnect.Tests.Brokerages.Tradier
             var accountId = TradierBrokerageFactory.Configuration.AccountId;
             var accessToken = TradierBrokerageFactory.Configuration.AccessToken;
 
-            return new TradierBrokerage(null, orderProvider, securityProvider, new AggregationManager(), useSandbox, accountId, accessToken);
+            return new TradierBrokerage(new AlgorithmStub(), orderProvider, securityProvider, new AggregationManager(), useSandbox, accountId, accessToken);
         }
 
         /// <summary>
@@ -161,7 +162,6 @@ namespace QuantConnect.Tests.Brokerages.Tradier
 
             // Raw response: {"errors":{"error":["Backoffice rejected override of the order.","DayTradingBuyingPowerExceeded"]}}
 
-            Assert.That(message.Contains("DayTradingBuyingPowerExceeded", StringComparison.InvariantCulture));
             Assert.That(message.Contains("Backoffice rejected override of the order", StringComparison.InvariantCulture));
         }
 

--- a/QuantConnect.TradierBrokerage/TradierBrokerage.HistoryProvider.cs
+++ b/QuantConnect.TradierBrokerage/TradierBrokerage.HistoryProvider.cs
@@ -30,6 +30,7 @@ namespace QuantConnect.Brokerages.Tradier
     /// </summary>
     public partial class TradierBrokerage
     {
+        private bool _loggedTradierSupportsOnlyTradeBars;
         #region IHistoryProvider implementation
 
         /// <summary>
@@ -99,8 +100,13 @@ namespace QuantConnect.Brokerages.Tradier
 
                 if (request.DataType == typeof(QuoteBar))
                 {
-                    Log.Error("TradierBrokerage.GetHistory(): Tradier only supports TradeBars");
-                    yield break;
+                    if (!_loggedTradierSupportsOnlyTradeBars)
+                    {
+                        _loggedTradierSupportsOnlyTradeBars = true;
+                        _algorithm?.Debug("Warning: Tradier history provider only supports trade information, does not support quotes.");
+                        Log.Error("TradierBrokerage.GetHistory(): Tradier only supports TradeBars");
+                    }
+                    continue;
                 }
 
                 var start = request.StartTimeUtc.ConvertTo(DateTimeZone.Utc, TimeZones.NewYork);


### PR DESCRIPTION
- `yield break` would skip the rest of the requested enumerators, use
  `continue` instead, log once the quote information warning

Tested in local live deployment