### PR TITLE
Retry transiently malformed REST responses before failing

### DIFF
--- a/QuantConnect.TradierBrokerage.Tests/TradierBrokerageAditionalTests.cs
+++ b/QuantConnect.TradierBrokerage.Tests/TradierBrokerageAditionalTests.cs
@@ -13,12 +13,19 @@
  * limitations under the License.
 */
 
+using Moq;
+using Newtonsoft.Json.Linq;
 using NUnit.Framework;
+using QuantConnect.Brokerages;
 using QuantConnect.Brokerages.Tradier;
 using QuantConnect.Interfaces;
 using QuantConnect.Orders;
 using QuantConnect.Util;
+using RestSharp;
 using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Reflection;
 
 namespace QuantConnect.Tests.Brokerages.Tradier
 {
@@ -68,6 +75,101 @@ namespace QuantConnect.Tests.Brokerages.Tradier
         public TradierOrderDirection ConvertsOrderDirection(OrderDirection direction, decimal holdingsQuantity, SecurityType securityType)
         {
             return TestableTradierBrokerage.ConvertDirectionPublic(direction, securityType, holdingsQuantity);
+        }
+
+        // Tradier's API can transiently serve a non-JSON body (e.g. its docs/maintenance HTML page) with a 200 status.
+        // Deserialization then throws; this must be treated as a transient failure and retried, not raised as a fatal
+        // error before the retry runs (see https://github.com/QuantConnect/Lean.Brokerages.Tradier/issues/45).
+        [Test]
+        public void RetriesTransientlyMalformedResponseInsteadOfFailing()
+        {
+            var htmlPage = "<!DOCTYPE html><html lang=\"en\"><head><title>Tradier API</title></head><body></body></html>";
+            var errors = new List<BrokerageMessageEvent>();
+            var restClient = new Mock<IRestClient>();
+            restClient.SetupSequence(x => x.Execute(It.IsAny<IRestRequest>()))
+                .Returns(CreateResponse(htmlPage))
+                .Returns(CreateResponse("{\"ok\":true}"));
+
+            var brokerage = CreateBrokerageWithRestClient(restClient.Object, errors);
+            var result = InvokeExecute<JObject>(brokerage, TradierApiRequestType.Standard, max: 3);
+
+            // the malformed body must not raise a fatal error before the retry, which succeeds and returns the payload
+            Assert.IsEmpty(errors);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(true, result["ok"].Value<bool>());
+            restClient.Verify(x => x.Execute(It.IsAny<IRestRequest>()), Times.Exactly(2));
+        }
+
+        [Test]
+        public void RaisesErrorOnlyAfterRetriesAreExhaustedOnMalformedResponse()
+        {
+            var htmlPage = "<!DOCTYPE html><html><head><title>Tradier API</title></head></html>";
+            var errors = new List<BrokerageMessageEvent>();
+            var restClient = new Mock<IRestClient>();
+            restClient.Setup(x => x.Execute(It.IsAny<IRestRequest>()))
+                .Returns(() => CreateResponse(htmlPage));
+
+            var brokerage = CreateBrokerageWithRestClient(restClient.Object, errors);
+            var result = InvokeExecute<JObject>(brokerage, TradierApiRequestType.Standard, max: 1);
+
+            // with max == 1: attempt 0 retries, attempt 1 exhausts retries and raises the fatal JsonError
+            Assert.IsNull(result);
+            Assert.AreEqual(1, errors.Count);
+            Assert.AreEqual("JsonError", errors[0].Code);
+            restClient.Verify(x => x.Execute(It.IsAny<IRestRequest>()), Times.Exactly(2));
+        }
+
+        private static IRestResponse CreateResponse(string content)
+        {
+            return new RestResponse
+            {
+                Content = content,
+                StatusCode = HttpStatusCode.OK,
+                ResponseStatus = ResponseStatus.Completed
+            };
+        }
+
+        // Builds a brokerage with just the state Execute needs (rest client + rate gate), skipping the heavy Initialize
+        // (license validation, timers, streaming threads) that a full construction would trigger.
+        private static TradierBrokerage CreateBrokerageWithRestClient(IRestClient restClient, List<BrokerageMessageEvent> errors)
+        {
+            var brokerage = new TradierBrokerage();
+            brokerage.Message += (_, e) =>
+            {
+                if (e.Type == BrokerageMessageType.Error)
+                {
+                    errors.Add(e);
+                }
+            };
+
+            SetPrivateField(typeof(BaseWebsocketsBrokerage), brokerage, "_restClient", restClient);
+            SetPrivateField(typeof(TradierBrokerage), brokerage, "_rateLimitNextRequest",
+                new Dictionary<TradierApiRequestType, RateGate>
+                {
+                    { TradierApiRequestType.Standard, new RateGate(1, TimeSpan.FromMilliseconds(1)) }
+                });
+
+            return brokerage;
+        }
+
+        private static T InvokeExecute<T>(TradierBrokerage brokerage, TradierApiRequestType type, int max) where T : new()
+        {
+            var method = typeof(TradierBrokerage)
+                .GetMethod("Execute", BindingFlags.NonPublic | BindingFlags.Instance)
+                .MakeGenericMethod(typeof(T));
+            try
+            {
+                return (T)method.Invoke(brokerage, new object[] { new RestRequest("user/profile", Method.GET), type, "", 0, max });
+            }
+            catch (TargetInvocationException e)
+            {
+                throw e.InnerException;
+            }
+        }
+
+        private static void SetPrivateField(Type type, object instance, string name, object value)
+        {
+            type.GetField(name, BindingFlags.NonPublic | BindingFlags.Instance).SetValue(instance, value);
         }
 
         private class TestableTradierBrokerage : TradierBrokerage

--- a/QuantConnect.TradierBrokerage/TradierBrokerage.cs
+++ b/QuantConnect.TradierBrokerage/TradierBrokerage.cs
@@ -253,6 +253,15 @@ namespace QuantConnect.Brokerages.Tradier
                 }
                 catch (Exception e)
                 {
+                    // a transiently malformed body (e.g. an HTML maintenance/error page served instead of JSON) can fail
+                    // deserialization; treat it like the other transient failures and retry before raising a fatal error
+                    Log.Error($"{method}(JsonError): Parameters: {string.Join(",", parameters)} Response: {raw.Content} Error: {e.Message}");
+                    if (attempts++ < max)
+                    {
+                        Log.Trace(method + "(JsonError): Attempting again...");
+                        Thread.Sleep(3000);
+                        return Execute<T>(request, type, rootName, attempts, max);
+                    }
                     OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, "JsonError", $"Error deserializing message: {raw.Content} Error: {e.Message}"));
                 }
 


### PR DESCRIPTION
Fixes #45

## Description

`TradierBrokerage.Execute<T>`'s deserialization `catch` raised a fatal `BrokerageMessageType.Error` ("JsonError") **immediately**, before the existing retry logic ran. `DefaultBrokerageMessageHandler` escalates that to a runtime error and stops the algorithm — so a single transiently malformed 200 body killed a live deployment even though the retry would have recovered.

This happened on a live deploy on 2026-06-11 when Tradier briefly served its docs HTML page (`<!DOCTYPE html>...<title>Tradier API</title>...`) for an `accounts/<id>/orders` request. The fatal `JsonError` fired at 11:36:06; the first retry only at 11:36:08, after `AlgorithmManager` was already stopping.

Only the `rootName == ""` deserialization path was affected — the non-empty-`rootName` path already routes through `TryDeserializeRemoveRoot`, which swallows the exception and falls through to the safe `response == null` retry block.

## Fix

The `catch` now mirrors the other transient-failure handlers in `Execute<T>`: log, sleep, and recurse while `attempts++ < max`, only raising the fatal `JsonError` once retries are exhausted.

## Tests

Two new tests in `TradierBrokerageAditionalTests` inject a mocked `IRestClient` into a minimally-populated brokerage (skipping the heavy `Initialize`) via reflection:

- `RetriesTransientlyMalformedResponseInsteadOfFailing` — HTML then valid JSON → no `Error` event, correct payload returned, called twice.
- `RaisesErrorOnlyAfterRetriesAreExhaustedOnMalformedResponse` — persistent HTML with `max: 1` → exactly one `JsonError` after retries are exhausted.

Both pass; the test project builds clean. The first test fails against the pre-fix code (the pre-retry `Error` event is captured), confirming it locks in the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)