### PR TITLE
Fix NRE and ignore external orders in data feed only mode

### DIFF
--- a/QuantConnect.TradierBrokerage/TradierBrokerage.cs
+++ b/QuantConnect.TradierBrokerage/TradierBrokerage.cs
@@ -1237,7 +1237,9 @@ Interval	Data Available (Open)	Data Available (All)
                             Log.Trace("TradierBrokerage.CheckForFills(): Verifying missing brokerage IDs: " + string.Join(",", localUnknownTradierOrderIDs));
                             var orders = localUnknownTradierOrderIDs.Select(x => _orderProvider?.GetOrdersByBrokerageId(x)?.SingleOrDefault()).Where(x => x != null);
                             var stillUnknownOrderIDs = localUnknownTradierOrderIDs.Where(x => !orders.Any(y => y.BrokerId.Contains(x.ToStringInvariant()))).ToList();
-                            if (stillUnknownOrderIDs.Count > 0)
+                            // without an order provider (data queue handler only mode) no order can be ours,
+                            // so don't treat orders placed externally in the account as an error
+                            if (_orderProvider != null && stillUnknownOrderIDs.Count > 0)
                             {
                                 // fetch all rejected intraday orders within the last minute, we're going to exclude rejected orders from the error condition
                                 var recentOrders = GetIntradayAndPendingOrders().Where(x => x.Status == TradierOrderStatus.Rejected)

--- a/QuantConnect.TradierBrokerage/TradierBrokerage.cs
+++ b/QuantConnect.TradierBrokerage/TradierBrokerage.cs
@@ -1235,7 +1235,7 @@ Interval	Data Available (Open)	Data Available (All)
                         {
                             // verify we don't have them in the order provider
                             Log.Trace("TradierBrokerage.CheckForFills(): Verifying missing brokerage IDs: " + string.Join(",", localUnknownTradierOrderIDs));
-                            var orders = localUnknownTradierOrderIDs.Select(x => _orderProvider.GetOrdersByBrokerageId(x)?.SingleOrDefault()).Where(x => x != null);
+                            var orders = localUnknownTradierOrderIDs.Select(x => _orderProvider?.GetOrdersByBrokerageId(x)?.SingleOrDefault()).Where(x => x != null);
                             var stillUnknownOrderIDs = localUnknownTradierOrderIDs.Where(x => !orders.Any(y => y.BrokerId.Contains(x.ToStringInvariant()))).ToList();
                             if (stillUnknownOrderIDs.Count > 0)
                             {


### PR DESCRIPTION
## Description

When `TradierBrokerage` is used only as a data queue handler (e.g. paper trading with Tradier data), `SetJob` initializes it without an order provider. The `CheckForFills` polling still runs, and when an order is placed externally in the linked Tradier account (Tradier UI or another deployment), the unknown-order-id resolution dereferences the null `_orderProvider` and throws:

```
ERROR:: TradierBrokerage.a():  System.NullReferenceException: Object reference not set to an instance of an object.
   at QuantConnect.Securities.OrderProviderExtensions.GetOrdersByBrokerageId(IOrderProvider orderProvider, Int64 brokerageId)
   ...
ERROR:: Extensions.SetRuntimeError(): RuntimeError ... Context: Brokerage Error
```

The runtime error stops the algorithm even though it does not trade through Tradier at all.

## Fix

- Use a null-conditional access on `_orderProvider` in the unknown order id verification, fixing the `NullReferenceException`.
- When there is no order provider (data feed only mode), no order can belong to the algorithm, so externally placed orders are marked as verified and ignored instead of raising the `UnknownOrderId` error that would stop the algorithm. Users consuming only Tradier data can keep trading in their linked account.

When Tradier is the actual brokerage nothing changes: unknown order ids are still resolved against the order provider and still stop the algorithm if unresolvable. The other two `_orderProvider` dereferences (`PlaceOrder` and `ProcessPotentiallyUpdatedOrder`) are only reachable in brokerage mode, where the factory always provides `algorithm.Transactions`, so they are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)