### PR TITLE
Retry transient Tradier fault responses before failing

### DIFF
--- a/QuantConnect.TradierBrokerage.Tests/TradierBrokerageAditionalTests.cs
+++ b/QuantConnect.TradierBrokerage.Tests/TradierBrokerageAditionalTests.cs
@@ -119,12 +119,73 @@ namespace QuantConnect.Tests.Brokerages.Tradier
             restClient.Verify(x => x.Execute(It.IsAny<IRestRequest>()), Times.Exactly(2));
         }
 
-        private static IRestResponse CreateResponse(string content)
+        // Tradier's gateway can transiently serve a JSON fault body (e.g. {"fault":{"faultstring":"Datastore Error"}})
+        // for backend problems. Only non-retryable authentication faults may fail fast; everything else must take the
+        // retry path (see https://github.com/QuantConnect/Lean.Brokerages.Tradier/issues/51).
+        [Test]
+        public void RetriesTransientFaultResponseInsteadOfFailing()
+        {
+            var faultBody = "{\"fault\":{\"faultstring\":\"Datastore Error\",\"detail\":{\"errorcode\":\"steps.servicecallout.ExecutionFailed\"}}}";
+            var errors = new List<BrokerageMessageEvent>();
+            var restClient = new Mock<IRestClient>();
+            restClient.SetupSequence(x => x.Execute(It.IsAny<IRestRequest>()))
+                .Returns(CreateResponse(faultBody, HttpStatusCode.InternalServerError))
+                .Returns(CreateResponse("{\"ok\":true}"));
+
+            var brokerage = CreateBrokerageWithRestClient(restClient.Object, errors);
+            var result = InvokeExecute<JObject>(brokerage, TradierApiRequestType.Standard, max: 3);
+
+            // the transient fault must not raise a fatal error before the retry, which succeeds and returns the payload
+            Assert.IsEmpty(errors);
+            Assert.IsNotNull(result);
+            Assert.AreEqual(true, result["ok"].Value<bool>());
+            restClient.Verify(x => x.Execute(It.IsAny<IRestRequest>()), Times.Exactly(2));
+        }
+
+        [Test]
+        public void RaisesErrorOnlyAfterRetriesAreExhaustedOnTransientFault()
+        {
+            var faultBody = "{\"fault\":{\"faultstring\":\"Datastore Error\",\"detail\":{\"errorcode\":\"steps.servicecallout.ExecutionFailed\"}}}";
+            var errors = new List<BrokerageMessageEvent>();
+            var restClient = new Mock<IRestClient>();
+            restClient.Setup(x => x.Execute(It.IsAny<IRestRequest>()))
+                .Returns(() => CreateResponse(faultBody, HttpStatusCode.InternalServerError));
+
+            var brokerage = CreateBrokerageWithRestClient(restClient.Object, errors);
+            var result = InvokeExecute<JObject>(brokerage, TradierApiRequestType.Standard, max: 1);
+
+            // with max == 1: attempt 0 retries, attempt 1 exhausts retries and raises the fatal error
+            Assert.IsNull(result);
+            Assert.AreEqual(1, errors.Count);
+            Assert.IsTrue(errors[0].Message.Contains("Datastore Error"));
+            restClient.Verify(x => x.Execute(It.IsAny<IRestRequest>()), Times.Exactly(2));
+        }
+
+        [TestCase("{\"fault\":{\"faultstring\":\"Invalid Access Token\",\"detail\":{\"errorcode\":\"keymanagement.service.invalid_access_token\"}}}", HttpStatusCode.Unauthorized)]
+        [TestCase("{\"fault\":{\"faultstring\":\"Access Token expired\",\"detail\":{\"errorcode\":\"keymanagement.service.access_token_expired\"}}}", HttpStatusCode.InternalServerError)]
+        public void FailsFastOnAuthenticationFault(string faultBody, HttpStatusCode statusCode)
+        {
+            var errors = new List<BrokerageMessageEvent>();
+            var restClient = new Mock<IRestClient>();
+            restClient.Setup(x => x.Execute(It.IsAny<IRestRequest>()))
+                .Returns(() => CreateResponse(faultBody, statusCode));
+
+            var brokerage = CreateBrokerageWithRestClient(restClient.Object, errors);
+            var result = InvokeExecute<JObject>(brokerage, TradierApiRequestType.Standard, max: 3);
+
+            // authentication faults are not retryable: fail fast with a single fatal error and no retry
+            Assert.IsNull(result);
+            Assert.AreEqual(1, errors.Count);
+            Assert.AreEqual("TradierFault", errors[0].Code);
+            restClient.Verify(x => x.Execute(It.IsAny<IRestRequest>()), Times.Once);
+        }
+
+        private static IRestResponse CreateResponse(string content, HttpStatusCode statusCode = HttpStatusCode.OK)
         {
             return new RestResponse
             {
                 Content = content,
-                StatusCode = HttpStatusCode.OK,
+                StatusCode = statusCode,
                 ResponseStatus = ResponseStatus.Completed
             };
         }
@@ -136,7 +197,9 @@ namespace QuantConnect.Tests.Brokerages.Tradier
             var brokerage = new TradierBrokerage();
             brokerage.Message += (_, e) =>
             {
-                if (e.Type == BrokerageMessageType.Error)
+                // OnMessage elevates NullResponse warnings to Error when the machine-local clock falls within
+                // US equity market hours; ignore them so these tests are deterministic regardless of run time
+                if (e.Type == BrokerageMessageType.Error && e.Code != "NullResponse")
                 {
                     errors.Add(e);
                 }

--- a/QuantConnect.TradierBrokerage/TradierBrokerage.cs
+++ b/QuantConnect.TradierBrokerage/TradierBrokerage.cs
@@ -183,13 +183,27 @@ namespace QuantConnect.Brokerages.Tradier
 
                 if (!raw.IsSuccessful)
                 {
-                    // fault errors on authentication
+                    Log.Error($"TradierBrokerage.Execute(1): {request.Method} {RestClient.BuildUri(request)} failed. " +
+                        $"Status: {raw.StatusCode} ({raw.ResponseStatus}). " +
+                        $"Parameters: {string.Join(", ", parameters)}. " +
+                        $"Error: {raw.ErrorMessage}. " +
+                        $"Response: {raw.Content}");
+
+                    // fault errors, e.g. {"fault":{"faultstring":"Datastore Error","detail":{...}}}
                     if (raw.Content.Contains("\"fault\""))
                     {
                         var fault = JsonConvert.DeserializeObject<TradierFaultContainer>(raw.Content);
-                        OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, "TradierFault", fault.Fault.Description));
+                        var description = fault?.Fault?.Description ?? raw.Content;
 
-                        return default(T);
+                        // fail fast only on non-retryable authentication faults (e.g. "Invalid Access Token");
+                        // transient backend faults (e.g. "Datastore Error") fall through to the retry logic below
+                        if (raw.StatusCode is HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden
+                            || description.Contains("Access Token", StringComparison.OrdinalIgnoreCase))
+                        {
+                            OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, "TradierFault", description));
+
+                            return default(T);
+                        }
                     }
 
                     // this happens when we try to cancel a filled or cancelled order
@@ -222,7 +236,6 @@ namespace QuantConnect.Brokerages.Tradier
                         return new T();
                     }
 
-                    Log.Error($"{method}(2): Parameters: {string.Join(",", parameters)} Response: {raw.Content}");
                     if (attempts++ < max)
                     {
                         Log.Trace(method + "(2): Attempting again...");


### PR DESCRIPTION
## Description

Closes #51.

`TradierBrokerage.Execute<T>` raised a fatal `BrokerageMessageType.Error` (which `DefaultBrokerageMessageHandler` escalates to a runtime error, stopping the algorithm) for **every** JSON fault body, even though the branch's comment says the intent is authentication faults. A single transient gateway fault killed a live deployment overnight on 2026-07-21 (see #51 for logs).

The fault branch now inspects the fault before dispatching:
- **Fail fast** only on non-retryable authentication/authorization faults: HTTP 401/403, or a fault description mentioning "Access Token" (defensive fallback).
- **All other faults** (e.g. `Datastore Error`) fall through to the existing transient-failure handling: log, sleep 3s, retry up to `max` attempts, and raise the fatal error only once retries are exhausted.

Also made the fault deserialization null-safe (`fault?.Fault?.Description ?? raw.Content`) — a body merely *containing* `"fault"` previously NRE'd if it didn't match the expected shape.

Every fault now logs `raw.StatusCode` alongside the body before dispatching. The incident syslog contains no HTTP status for the `Datastore Error` fault because the old branch discarded it — this closes that observability gap. (The customer's syslogs do confirm the auth side of the split: an authorization failure on the orders endpoint surfaced as `Error - Code: Unauthorized`, i.e. HTTP 401, matching the Apigee reference below.)

## What "Datastore Error" means (context for review)

Tradier fronts its API with Apigee. Apigee keeps its own operational data — API keys, OAuth tokens, quota counters — in an internal Cassandra datastore. When the gateway's lookup against that store times out or fails mid-request, Apigee aborts the request with `{"fault":{"faultstring":"Datastore Error",...}}` and a 500-class status. It is an internal gateway infrastructure hiccup, not a problem with the request: in the incident that motivated #51, the same `accounts/<id>/orders` poll succeeded 20 ms after the fatal fault. That is why it belongs on the retry path.

The 401/403-vs-500 split is backed by Apigee's documentation: **all** token/auth faults ship with HTTP 401 ("Invalid Access Token", "Access Token expired", "Access Token not approved", "Invalid API call as no apiproduct match found") or 403 (insufficient scope), while backend faults use 500-class statuses. Reference: [Apigee OAuth HTTP status code reference](https://docs.apigee.com/api-platform/reference/policies/oauth-http-status-code-reference).

## Related

- #45 / #49 fixed the same fatal-before-retry defect in the JSON-deserialization `catch` of this method; this PR fixes the remaining fatal-before-retry path and reuses the mocked-`IRestClient` test harness introduced there.
- Related: #14.

## Testing

Four new unit tests in `TradierBrokerageAditionalTests`:
- `RetriesTransientFaultResponseInsteadOfFailing` — `Datastore Error` fault (HTTP 500) then a good response: no error raised, payload returned, exactly 2 REST calls.
- `RaisesErrorOnlyAfterRetriesAreExhaustedOnTransientFault` — persistent fault: single fatal error only after retries are exhausted.
- `FailsFastOnAuthenticationFault` — "Invalid Access Token" with 401, and "Access Token expired" even with a 500 status (exercises the description fallback): single `TradierFault` error, no retry.

Full fixture: 30/30 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
