### PR TITLE
fix: stop serializing api calls in execute

### DIFF
--- a/QuantConnect.TradierBrokerage.Tests/TradierBrokerageAditionalTests.cs
+++ b/QuantConnect.TradierBrokerage.Tests/TradierBrokerageAditionalTests.cs
@@ -263,7 +263,8 @@ namespace QuantConnect.Tests.Brokerages.Tradier
         public void PlacesOrderBurstWithinTradingRateLimit()
         {
             var orderProvider = new OrderProvider();
-            using var brokerage = CreateLiveBrokerage(orderProvider, new SecurityProvider());
+            var securityProvider = new SecurityProvider();
+            using var brokerage = CreateLiveBrokerage(orderProvider, securityProvider);
             var messages = new ConcurrentBag<BrokerageMessageEvent>();
             brokerage.Message += (_, e) => messages.Add(e);
 
@@ -272,6 +273,11 @@ namespace QuantConnect.Tests.Brokerages.Tradier
             var orders = quotes.Select(quote => new LimitOrder(Symbol.Create(quote.Symbol, SecurityType.Equity, Market.USA), 1,
                 Math.Max(0.01m, Math.Round(quote.Last / 2, 2)), DateTime.UtcNow, properties: new OrderProperties { TimeInForce = TimeInForce.Day })).ToList();
             orders.ForEach(orderProvider.Add);
+            // create the securities up front, the test security provider is not thread safe
+            orders.ForEach(order => securityProvider.GetSecurity(order.Symbol));
+
+            // orders left open on these symbols by earlier runs do not count
+            var openBefore = brokerage.GetOpenOrders().Count(x => orders.Any(o => o.Symbol == x.Symbol));
 
             var stopwatch = Stopwatch.StartNew();
             var placements = orders.Select(order => Task.Run(() => (Order: order, Placed: brokerage.PlaceOrder(order), ReturnedAt: stopwatch.Elapsed))).ToArray();
@@ -296,7 +302,7 @@ namespace QuantConnect.Tests.Brokerages.Tradier
             Assert.AreEqual(100, placed.Count, "not every order was placed: " + string.Join(" | ", messages.Where(x => x.Type != BrokerageMessageType.Information).Select(x => x.Message).Take(5)));
             Assert.AreEqual(100, brokerIds.Distinct().Count(), "duplicate broker ids");
             Assert.AreEqual(100, openById, "Tradier did not show every placed order as open");
-            Assert.AreEqual(100, openBySymbol, "Tradier shows extra orders on the burst symbols, possible duplicates");
+            Assert.AreEqual(openBefore + 100, openBySymbol, "Tradier shows extra orders on the burst symbols, possible duplicates");
             Assert.AreEqual(100, cancels.Count(x => x.Result), "not every order was cancelled");
         }
 

--- a/QuantConnect.TradierBrokerage.Tests/TradierBrokerageAditionalTests.cs
+++ b/QuantConnect.TradierBrokerage.Tests/TradierBrokerageAditionalTests.cs
@@ -25,6 +25,7 @@ using RestSharp;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Threading;
@@ -232,7 +233,7 @@ namespace QuantConnect.Tests.Brokerages.Tradier
             Assert.IsTrue(firstAttemptSent.Wait(TimeSpan.FromSeconds(5)), "the rejected request never sent its first attempt");
 
             // the account request must not wait for that sleep
-            var accountRequest = Task.Run(brokerage.GetUserProfile);
+            var accountRequest = Task.Run(brokerage.GetCashBalance);
             Assert.IsTrue(accountRequest.Wait(TimeSpan.FromSeconds(1.5)), "the account request waited on the retrying rejected request");
             Assert.IsNotNull(accountRequest.Result);
 
@@ -307,11 +308,12 @@ namespace QuantConnect.Tests.Brokerages.Tradier
         private static T InvokeExecute<T>(TradierBrokerage brokerage, TradierApiRequestType type, int max, string resource = "user/profile") where T : new()
         {
             var method = typeof(TradierBrokerage)
-                .GetMethod("Execute", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetMethods(BindingFlags.NonPublic | BindingFlags.Instance)
+                .Single(x => x.Name == "Execute" && !x.GetParameters().Any(p => p.IsOut))
                 .MakeGenericMethod(typeof(T));
             try
             {
-                return (T)method.Invoke(brokerage, new object[] { new RestRequest(resource, Method.GET), type, "", 0, max });
+                return (T)method.Invoke(brokerage, new object[] { new RestRequest(resource, Method.GET), type, "", max });
             }
             catch (TargetInvocationException e)
             {

--- a/QuantConnect.TradierBrokerage.Tests/TradierBrokerageAditionalTests.cs
+++ b/QuantConnect.TradierBrokerage.Tests/TradierBrokerageAditionalTests.cs
@@ -257,7 +257,7 @@ namespace QuantConnect.Tests.Brokerages.Tradier
         };
 
         // Sends 100 limit orders to the real API at the same time, far below the market so nothing fills, then cancels them.
-        // Tradier allows 60 trading requests per minute: the first 60 should go out at once and the rest wait for free slots,
+        // Tradier allows 60 trading requests per minute and the plugin stays a bit below that: the first batch goes out at once and the rest wait for free slots,
         // with no 429 and no duplicate orders. Costs about 200 trading requests and 2 to 3 minutes.
         [Test, Explicit("Places and cancels 100 orders in the Tradier sandbox")]
         public void PlacesOrderBurstWithinTradingRateLimit()
@@ -284,8 +284,9 @@ namespace QuantConnect.Tests.Brokerages.Tradier
             Assert.IsTrue(Task.WaitAll(placements, TimeSpan.FromMinutes(3)), "placing 100 orders did not finish in 3 minutes");
             var results = placements.Select(x => x.Result).OrderBy(x => x.ReturnedAt).ToList();
             var placed = results.Where(x => x.Placed).Select(x => x.Order).ToList();
+            var longestWait = Enumerable.Range(1, results.Count - 1).Select(i => (Request: i + 1, Wait: results[i].ReturnedAt - results[i - 1].ReturnedAt)).OrderByDescending(x => x.Wait).First();
             Log.Trace($"PlacesOrderBurstWithinTradingRateLimit(): placed {placed.Count}/100 in {stopwatch.Elapsed}; " +
-                $"request 1 returned at {results[0].ReturnedAt}, 60 at {results[59].ReturnedAt}, 61 at {results[60].ReturnedAt}, 100 at {results[^1].ReturnedAt}; " +
+                $"request 1 returned at {results[0].ReturnedAt}, 100 at {results[^1].ReturnedAt}; longest wait {longestWait.Wait} before request {longestWait.Request}; " +
                 $"message codes: {string.Join(", ", messages.Select(x => x.Code).Distinct())}");
 
             // what Tradier holds for these orders, before the clean up

--- a/QuantConnect.TradierBrokerage.Tests/TradierBrokerageAditionalTests.cs
+++ b/QuantConnect.TradierBrokerage.Tests/TradierBrokerageAditionalTests.cs
@@ -24,8 +24,11 @@ using QuantConnect.Util;
 using RestSharp;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Net;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace QuantConnect.Tests.Brokerages.Tradier
 {
@@ -180,6 +183,63 @@ namespace QuantConnect.Tests.Brokerages.Tradier
             restClient.Verify(x => x.Execute(It.IsAny<IRestRequest>()), Times.Once);
         }
 
+        [Test]
+        public void DoesNotBlockOtherRequestsWhileRetrying()
+        {
+            var errors = new List<BrokerageMessageEvent>();
+            var firstAttemptSent = new ManualResetEventSlim(false);
+            var restClient = new Mock<IRestClient>();
+            // the order request fails with a 500 on its first attempt and succeeds on the retry
+            restClient.Setup(x => x.Execute(It.Is<IRestRequest>(r => r.Resource == "accounts/orders")))
+                .Returns(() =>
+                {
+                    if (firstAttemptSent.IsSet)
+                    {
+                        return CreateResponse("{\"ok\":true}");
+                    }
+                    firstAttemptSent.Set();
+                    return CreateResponse("Internal Server Error", HttpStatusCode.InternalServerError);
+                });
+            // the account request succeeds right away
+            restClient.Setup(x => x.Execute(It.Is<IRestRequest>(r => r.Resource == "user/profile")))
+                .Returns(CreateResponse("{\"ok\":true}"));
+
+            var brokerage = CreateBrokerageWithRestClient(restClient.Object, errors);
+            var orderRequest = Task.Run(() => InvokeExecute<JObject>(brokerage, TradierApiRequestType.Orders, max: 1, resource: "accounts/orders"));
+            Assert.IsTrue(firstAttemptSent.Wait(TimeSpan.FromSeconds(5)), "the order request never sent its first attempt");
+
+            // the order request is now sleeping before its retry; the account request must not wait for it
+            var accountRequest = Task.Run(() => InvokeExecute<JObject>(brokerage, TradierApiRequestType.Standard, max: 1));
+            Assert.IsTrue(accountRequest.Wait(TimeSpan.FromSeconds(1)), "the account request waited on the retrying order request");
+            Assert.AreEqual(true, accountRequest.Result["ok"].Value<bool>());
+
+            Assert.IsTrue(orderRequest.Wait(TimeSpan.FromSeconds(10)), "the order request never completed its retry");
+            Assert.AreEqual(true, orderRequest.Result["ok"].Value<bool>());
+            Assert.IsEmpty(errors);
+        }
+
+        // Live version of the test above, against the Tradier sandbox. Costs three sandbox requests and about four seconds.
+        [Test, Explicit("Requires Tradier sandbox credentials")]
+        public void DoesNotBlockOtherRequestsWhileRetryingLive()
+        {
+            using var brokerage = CreateLiveBrokerage();
+            var rejectedResource = $"accounts/{TradierBrokerageFactory.Configuration.AccountId}/does-not-exist";
+            var firstAttemptSent = SignalFirstResponse(brokerage, rejectedResource);
+
+            // Tradier rejects the path, so Execute sleeps 3 s before its single retry
+            var stopwatch = Stopwatch.StartNew();
+            var rejectedRequest = Task.Run(() => InvokeExecute<JObject>(brokerage, TradierApiRequestType.Orders, max: 1, resource: rejectedResource));
+            Assert.IsTrue(firstAttemptSent.Wait(TimeSpan.FromSeconds(5)), "the rejected request never sent its first attempt");
+
+            // the account request must not wait for that sleep
+            var accountRequest = Task.Run(brokerage.GetUserProfile);
+            Assert.IsTrue(accountRequest.Wait(TimeSpan.FromSeconds(1.5)), "the account request waited on the retrying rejected request");
+            Assert.IsNotNull(accountRequest.Result);
+
+            Assert.IsTrue(rejectedRequest.Wait(TimeSpan.FromSeconds(15)), "the rejected request never completed its retry");
+            Assert.IsTrue(stopwatch.Elapsed >= TimeSpan.FromSeconds(3), "the rejected request did not go through the retry sleep");
+        }
+
         private static IRestResponse CreateResponse(string content, HttpStatusCode statusCode = HttpStatusCode.OK)
         {
             return new RestResponse
@@ -209,20 +269,49 @@ namespace QuantConnect.Tests.Brokerages.Tradier
             SetPrivateField(typeof(TradierBrokerage), brokerage, "_rateLimitNextRequest",
                 new Dictionary<TradierApiRequestType, RateGate>
                 {
-                    { TradierApiRequestType.Standard, new RateGate(1, TimeSpan.FromMilliseconds(1)) }
+                    { TradierApiRequestType.Standard, new RateGate(1, TimeSpan.FromMilliseconds(1)) },
+                    { TradierApiRequestType.Orders, new RateGate(1, TimeSpan.FromMilliseconds(1)) }
                 });
 
             return brokerage;
         }
 
-        private static T InvokeExecute<T>(TradierBrokerage brokerage, TradierApiRequestType type, int max) where T : new()
+        // Builds a brokerage for the account in config.json, reading the sandbox flag the same way the factory does
+        private static TradierBrokerage CreateLiveBrokerage()
+        {
+            var environment = TradierBrokerageFactory.Configuration.Environment;
+            var useSandbox = string.IsNullOrEmpty(environment) ? TradierBrokerageFactory.Configuration.UseSandbox : environment.ToLowerInvariant() == "paper";
+            return new TradierBrokerage(null, null, null, null, useSandbox, TradierBrokerageFactory.Configuration.AccountId, TradierBrokerageFactory.Configuration.AccessToken);
+        }
+
+        // Swaps in a rest client that still calls Tradier and signals once a request for the resource has its response
+        private static ManualResetEventSlim SignalFirstResponse(TradierBrokerage brokerage, string resource)
+        {
+            var signal = new ManualResetEventSlim(false);
+            var realRestClient = GetPrivateField<IRestClient>(typeof(BaseWebsocketsBrokerage), brokerage, "_restClient");
+            var restClient = new Mock<IRestClient>();
+            restClient.Setup(x => x.Execute(It.IsAny<IRestRequest>()))
+                .Returns((IRestRequest request) =>
+                {
+                    var response = realRestClient.Execute(request);
+                    if (request.Resource == resource)
+                    {
+                        signal.Set();
+                    }
+                    return response;
+                });
+            SetPrivateField(typeof(BaseWebsocketsBrokerage), brokerage, "_restClient", restClient.Object);
+            return signal;
+        }
+
+        private static T InvokeExecute<T>(TradierBrokerage brokerage, TradierApiRequestType type, int max, string resource = "user/profile") where T : new()
         {
             var method = typeof(TradierBrokerage)
                 .GetMethod("Execute", BindingFlags.NonPublic | BindingFlags.Instance)
                 .MakeGenericMethod(typeof(T));
             try
             {
-                return (T)method.Invoke(brokerage, new object[] { new RestRequest("user/profile", Method.GET), type, "", 0, max });
+                return (T)method.Invoke(brokerage, new object[] { new RestRequest(resource, Method.GET), type, "", 0, max });
             }
             catch (TargetInvocationException e)
             {
@@ -233,6 +322,11 @@ namespace QuantConnect.Tests.Brokerages.Tradier
         private static void SetPrivateField(Type type, object instance, string name, object value)
         {
             type.GetField(name, BindingFlags.NonPublic | BindingFlags.Instance).SetValue(instance, value);
+        }
+
+        private static T GetPrivateField<T>(Type type, object instance, string name)
+        {
+            return (T)type.GetField(name, BindingFlags.NonPublic | BindingFlags.Instance).GetValue(instance);
         }
 
         private class TestableTradierBrokerage : TradierBrokerage

--- a/QuantConnect.TradierBrokerage.Tests/TradierBrokerageAditionalTests.cs
+++ b/QuantConnect.TradierBrokerage.Tests/TradierBrokerageAditionalTests.cs
@@ -19,10 +19,13 @@ using NUnit.Framework;
 using QuantConnect.Brokerages;
 using QuantConnect.Brokerages.Tradier;
 using QuantConnect.Interfaces;
+using QuantConnect.Logging;
 using QuantConnect.Orders;
+using QuantConnect.Securities;
 using QuantConnect.Util;
 using RestSharp;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -241,6 +244,62 @@ namespace QuantConnect.Tests.Brokerages.Tradier
             Assert.IsTrue(stopwatch.Elapsed >= TimeSpan.FromSeconds(3), "the rejected request did not go through the retry sleep");
         }
 
+        // one order per symbol, because the plugin allows only one open order per symbol
+        private static readonly string[] BurstTickers =
+        {
+            "AAPL", "MSFT", "AMZN", "GOOGL", "GOOG", "META", "NVDA", "TSLA", "JPM", "JNJ", "V", "PG", "UNH", "HD", "MA", "XOM",
+            "BAC", "PFE", "ABBV", "KO", "PEP", "CSCO", "CVX", "TMO", "AVGO", "COST", "MRK", "WMT", "DIS", "ABT", "ACN", "ADBE",
+            "CRM", "DHR", "MCD", "NKE", "NFLX", "LLY", "VZ", "T", "INTC", "CMCSA", "WFC", "ORCL", "QCOM", "TXN", "AMD", "HON",
+            "UNP", "PM", "LOW", "IBM", "AMGN", "CAT", "GS", "MS", "BLK", "SBUX", "INTU", "GE", "RTX", "BA", "DE", "LMT", "SPGI",
+            "AXP", "BKNG", "GILD", "MDT", "ADP", "MDLZ", "TJX", "C", "CVS", "SCHW", "MMM", "USB", "CB", "ELV", "BMY", "PLD",
+            "SO", "DUK", "NEE", "MO", "TGT", "CL", "PYPL", "AMAT", "ISRG", "ADI", "REGN", "VRTX", "ZTS", "PGR", "BDX", "CI",
+            "MU", "LRCX", "F", "GM", "UBER", "ABNB", "PLTR", "KHC", "GIS", "EBAY", "MAR", "HLT"
+        };
+
+        // Sends 100 limit orders to the real API at the same time, far below the market so nothing fills, then cancels them.
+        // Tradier allows 60 trading requests per minute: the first 60 should go out at once and the rest wait for free slots,
+        // with no 429 and no duplicate orders. Costs about 200 trading requests and 2 to 3 minutes.
+        [Test, Explicit("Places and cancels 100 orders in the Tradier sandbox")]
+        public void PlacesOrderBurstWithinTradingRateLimit()
+        {
+            var orderProvider = new OrderProvider();
+            using var brokerage = CreateLiveBrokerage(orderProvider, new SecurityProvider());
+            var messages = new ConcurrentBag<BrokerageMessageEvent>();
+            brokerage.Message += (_, e) => messages.Add(e);
+
+            var quotes = brokerage.GetQuotes(BurstTickers.ToList()).Where(x => x.Last > 0).Take(100).ToList();
+            Assert.AreEqual(100, quotes.Count, "not enough quoted symbols for the burst");
+            var orders = quotes.Select(quote => new LimitOrder(Symbol.Create(quote.Symbol, SecurityType.Equity, Market.USA), 1,
+                Math.Max(0.01m, Math.Round(quote.Last / 2, 2)), DateTime.UtcNow, properties: new OrderProperties { TimeInForce = TimeInForce.Day })).ToList();
+            orders.ForEach(orderProvider.Add);
+
+            var stopwatch = Stopwatch.StartNew();
+            var placements = orders.Select(order => Task.Run(() => (Order: order, Placed: brokerage.PlaceOrder(order), ReturnedAt: stopwatch.Elapsed))).ToArray();
+            Assert.IsTrue(Task.WaitAll(placements, TimeSpan.FromMinutes(3)), "placing 100 orders did not finish in 3 minutes");
+            var results = placements.Select(x => x.Result).OrderBy(x => x.ReturnedAt).ToList();
+            var placed = results.Where(x => x.Placed).Select(x => x.Order).ToList();
+            Log.Trace($"PlacesOrderBurstWithinTradingRateLimit(): placed {placed.Count}/100 in {stopwatch.Elapsed}; " +
+                $"request 1 returned at {results[0].ReturnedAt}, 60 at {results[59].ReturnedAt}, 61 at {results[60].ReturnedAt}, 100 at {results[^1].ReturnedAt}; " +
+                $"message codes: {string.Join(", ", messages.Select(x => x.Code).Distinct())}");
+
+            // what Tradier holds for these orders, before the clean up
+            var brokerIds = placed.SelectMany(x => x.BrokerId).ToList();
+            var openOrders = brokerage.GetOpenOrders();
+            var openById = openOrders.Count(x => x.BrokerId.Any(brokerIds.Contains));
+            var openBySymbol = openOrders.Count(x => orders.Any(o => o.Symbol == x.Symbol));
+
+            var cancels = placed.Select(order => Task.Run(() => brokerage.CancelOrder(order))).ToArray();
+            Assert.IsTrue(Task.WaitAll(cancels, TimeSpan.FromMinutes(3)), "cancelling the orders did not finish in 3 minutes");
+            Log.Trace($"PlacesOrderBurstWithinTradingRateLimit(): cancelled {cancels.Count(x => x.Result)}/{placed.Count} in {stopwatch.Elapsed}");
+
+            Assert.IsEmpty(messages.Where(x => x.Code == "TooManyRequests"), "Tradier answered 429 during the burst");
+            Assert.AreEqual(100, placed.Count, "not every order was placed: " + string.Join(" | ", messages.Where(x => x.Type != BrokerageMessageType.Information).Select(x => x.Message).Take(5)));
+            Assert.AreEqual(100, brokerIds.Distinct().Count(), "duplicate broker ids");
+            Assert.AreEqual(100, openById, "Tradier did not show every placed order as open");
+            Assert.AreEqual(100, openBySymbol, "Tradier shows extra orders on the burst symbols, possible duplicates");
+            Assert.AreEqual(100, cancels.Count(x => x.Result), "not every order was cancelled");
+        }
+
         private static IRestResponse CreateResponse(string content, HttpStatusCode statusCode = HttpStatusCode.OK)
         {
             return new RestResponse
@@ -278,11 +337,11 @@ namespace QuantConnect.Tests.Brokerages.Tradier
         }
 
         // Builds a brokerage for the account in config.json, reading the sandbox flag the same way the factory does
-        private static TradierBrokerage CreateLiveBrokerage()
+        private static TradierBrokerage CreateLiveBrokerage(IOrderProvider orderProvider = null, ISecurityProvider securityProvider = null)
         {
             var environment = TradierBrokerageFactory.Configuration.Environment;
             var useSandbox = string.IsNullOrEmpty(environment) ? TradierBrokerageFactory.Configuration.UseSandbox : environment.ToLowerInvariant() == "paper";
-            return new TradierBrokerage(null, null, null, null, useSandbox, TradierBrokerageFactory.Configuration.AccountId, TradierBrokerageFactory.Configuration.AccessToken);
+            return new TradierBrokerage(null, orderProvider, securityProvider, null, useSandbox, TradierBrokerageFactory.Configuration.AccountId, TradierBrokerageFactory.Configuration.AccessToken);
         }
 
         // Swaps in a rest client that still calls Tradier and signals once a request for the resource has its response

--- a/QuantConnect.TradierBrokerage/TradierBrokerage.cs
+++ b/QuantConnect.TradierBrokerage/TradierBrokerage.cs
@@ -76,9 +76,6 @@ namespace QuantConnect.Brokerages.Tradier
         private readonly SymbolPropertiesDatabase _symbolPropertiesDatabase = SymbolPropertiesDatabase.FromDataFolder();
         private TradierSymbolMapper _symbolMapper;
 
-        private string _previousResponseRaw = "";
-        private readonly object _lockAccessCredentials = new object();
-
         // polling timer for checking for fill events
         private Timer _orderFillTimer;
 
@@ -160,26 +157,32 @@ namespace QuantConnect.Brokerages.Tradier
         /// <summary>
         /// Execute a authenticated call:
         /// </summary>
-        private T Execute<T>(RestRequest request, TradierApiRequestType type, string rootName = "", int attempts = 0, int max = 10) where T : new()
+        private T Execute<T>(RestRequest request, TradierApiRequestType type, string rootName = "", int max = 10) where T : new()
         {
-            var response = default(T);
+            return Execute<T>(request, type, out _, rootName, max);
+        }
 
+        /// <summary>
+        /// Execute a authenticated call and hand back the raw body of the last response:
+        /// </summary>
+        private T Execute<T>(RestRequest request, TradierApiRequestType type, out string rawContent, string rootName = "", int max = 10) where T : new()
+        {
             var method = "TradierBrokerage.Execute." + request.Resource;
             var parameters = request.Parameters.Select(x => x.Name + ": " + x.Value);
 
-            if (attempts != 0)
+            for (var attempt = 0; ; attempt++)
             {
-                Log.Trace(method + "(): Begin attempt " + attempts);
-            }
+                if (attempt != 0)
+                {
+                    Log.Trace(method + "(): Begin attempt " + attempt);
+                }
 
-            lock (_lockAccessCredentials)
-            {
                 //Wait for the API rate limiting
                 _rateLimitNextRequest[type].WaitToProceed();
 
                 //Send the request:
                 var raw = RestClient.Execute(request);
-                _previousResponseRaw = raw.Content;
+                rawContent = raw.Content;
 
                 if (!raw.IsSuccessful)
                 {
@@ -236,18 +239,19 @@ namespace QuantConnect.Brokerages.Tradier
                         return new T();
                     }
 
-                    if (attempts++ < max)
+                    if (attempt < max)
                     {
                         Log.Trace(method + "(2): Attempting again...");
                         // this will retry on time outs and other transport exception
                         Thread.Sleep(3000);
-                        return Execute<T>(request, type, rootName, attempts, max);
+                        continue;
                     }
                     OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, raw.StatusCode.ToStringInvariant(), raw.Content));
 
                     return default(T);
                 }
 
+                var response = default(T);
                 try
                 {
                     if (!string.IsNullOrEmpty(rootName))
@@ -269,23 +273,23 @@ namespace QuantConnect.Brokerages.Tradier
                     // a transiently malformed body (e.g. an HTML maintenance/error page served instead of JSON) can fail
                     // deserialization; treat it like the other transient failures and retry before raising a fatal error
                     Log.Error($"{method}(JsonError): Parameters: {string.Join(",", parameters)} Response: {raw.Content} Error: {e.Message}");
-                    if (attempts++ < max)
+                    if (attempt < max)
                     {
                         Log.Trace(method + "(JsonError): Attempting again...");
                         Thread.Sleep(3000);
-                        return Execute<T>(request, type, rootName, attempts, max);
+                        continue;
                     }
                     OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, "JsonError", $"Error deserializing message: {raw.Content} Error: {e.Message}"));
                 }
 
                 if (raw.ErrorException != null)
                 {
-                    if (attempts++ < max)
+                    if (attempt < max)
                     {
                         Log.Trace(method + "(3): Attempting again...");
                         // this will retry on time outs and other transport exception
                         Thread.Sleep(3000);
-                        return Execute<T>(request, type, rootName, attempts, max);
+                        continue;
                     }
 
                     Log.Trace(method + "(3): Parameters: " + string.Join(",", parameters));
@@ -294,24 +298,24 @@ namespace QuantConnect.Brokerages.Tradier
                     const string message = "Error retrieving response.  Check inner details for more info.";
                     throw new ApplicationException(message, raw.ErrorException);
                 }
-            }
 
-            if (response == null)
-            {
-                if (attempts++ < max)
+                if (response == null)
                 {
-                    Log.Trace(method + "(4): Attempting again...");
-                    // this will retry on time outs and other transport exception
-                    Thread.Sleep(3000);
-                    return Execute<T>(request, type, rootName, attempts, max);
+                    if (attempt < max)
+                    {
+                        Log.Trace(method + "(4): Attempting again...");
+                        // this will retry on time outs and other transport exception
+                        Thread.Sleep(3000);
+                        continue;
+                    }
+
+                    Log.Trace(method + "(4): Parameters: " + string.Join(",", parameters));
+                    Log.Error(method + "(4): NULL Response: Raw Response: " + raw.Content);
+                    OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "NullResponse", raw.Content));
                 }
 
-                Log.Trace(method + "(4): Parameters: " + string.Join(",", parameters));
-                Log.Error(method + "(4): NULL Response: Raw Response: " + _previousResponseRaw);
-                OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Warning, "NullResponse", _previousResponseRaw));
+                return response;
             }
-
-            return response;
         }
 
         /// <summary>
@@ -449,11 +453,12 @@ namespace QuantConnect.Brokerages.Tradier
             TradierOrderDirection direction,
             string symbol,
             decimal quantity,
-            decimal price = 0,
-            decimal stop = 0,
-            string optionSymbol = "",
-            TradierOrderType type = TradierOrderType.Market,
-            TradierOrderDuration duration = TradierOrderDuration.GTC)
+            decimal price,
+            decimal stop,
+            string optionSymbol,
+            TradierOrderType type,
+            TradierOrderDuration duration,
+            out string rawContent)
         {
             //Compose the request:
             var request = new RestRequest($"accounts/{_accountId}/orders");
@@ -474,7 +479,7 @@ namespace QuantConnect.Brokerages.Tradier
             //Set Method:
             request.Method = Method.POST;
 
-            return Execute<TradierOrderResponse>(request, TradierApiRequestType.Orders);
+            return Execute<TradierOrderResponse>(request, TradierApiRequestType.Orders, out rawContent);
         }
 
         /// <summary>
@@ -1081,7 +1086,8 @@ Interval	Data Available (Open)	Data Available (All)
                 order.Stop,
                 order.OptionSymbol,
                 order.Type,
-                order.Duration
+                order.Duration,
+                out var rawContent
                 );
 
             // if no errors, add to our open orders collection
@@ -1128,7 +1134,7 @@ Interval	Data Available (Open)	Data Available (All)
                 OnOrderEvent(new OrderEvent(order.QCOrder, DateTime.UtcNow, OrderFee.Zero)
                 { Status = OrderStatus.Invalid });
 
-                string message = _previousResponseRaw;
+                string message = rawContent;
                 if (response != null && response.Errors != null && !response.Errors.Errors.IsNullOrEmpty())
                 {
                     message = "Order " + order.QCOrder.Id + ": " + string.Join(Environment.NewLine, response.Errors.Errors);
@@ -1840,11 +1846,14 @@ Interval	Data Available (Open)	Data Available (All)
 
             // we can poll orders once a second in sandbox and twice a second in production
             var interval = _useSandbox ? 1000 : 500;
+
+            // Tradier limits, per minute and per access token (https://docs.tradier.com/docs/rate-limiting):
+            var requestsPerMinute = _useSandbox ? 60 : 120;
             _rateLimitNextRequest = new Dictionary<TradierApiRequestType, RateGate>
             {
-                { TradierApiRequestType.Data, new RateGate(1, TimeSpan.FromMilliseconds(interval))},
-                { TradierApiRequestType.Standard, new RateGate(1, TimeSpan.FromMilliseconds(interval))},
-                { TradierApiRequestType.Orders, new RateGate(1, TimeSpan.FromMilliseconds(1000))},
+                { TradierApiRequestType.Data, new RateGate(requestsPerMinute, TimeSpan.FromMinutes(1))},
+                { TradierApiRequestType.Standard, new RateGate(requestsPerMinute, TimeSpan.FromMinutes(1))},
+                { TradierApiRequestType.Orders, new RateGate(60, TimeSpan.FromMinutes(1))},
             };
 
             _orderFillTimer = new Timer(state => CheckForFills(), null, interval, interval);

--- a/QuantConnect.TradierBrokerage/TradierBrokerage.cs
+++ b/QuantConnect.TradierBrokerage/TradierBrokerage.cs
@@ -174,6 +174,7 @@ namespace QuantConnect.Brokerages.Tradier
             {
                 if (attempt != 0)
                 {
+                    Thread.Sleep(3000);
                     Log.Trace(method + "(): Begin attempt " + attempt);
                 }
 
@@ -242,8 +243,6 @@ namespace QuantConnect.Brokerages.Tradier
                     if (attempt < max)
                     {
                         Log.Trace(method + "(2): Attempting again...");
-                        // this will retry on time outs and other transport exception
-                        Thread.Sleep(3000);
                         continue;
                     }
                     OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, raw.StatusCode.ToStringInvariant(), raw.Content));
@@ -276,7 +275,6 @@ namespace QuantConnect.Brokerages.Tradier
                     if (attempt < max)
                     {
                         Log.Trace(method + "(JsonError): Attempting again...");
-                        Thread.Sleep(3000);
                         continue;
                     }
                     OnMessage(new BrokerageMessageEvent(BrokerageMessageType.Error, "JsonError", $"Error deserializing message: {raw.Content} Error: {e.Message}"));
@@ -287,8 +285,6 @@ namespace QuantConnect.Brokerages.Tradier
                     if (attempt < max)
                     {
                         Log.Trace(method + "(3): Attempting again...");
-                        // this will retry on time outs and other transport exception
-                        Thread.Sleep(3000);
                         continue;
                     }
 
@@ -304,8 +300,6 @@ namespace QuantConnect.Brokerages.Tradier
                     if (attempt < max)
                     {
                         Log.Trace(method + "(4): Attempting again...");
-                        // this will retry on time outs and other transport exception
-                        Thread.Sleep(3000);
                         continue;
                     }
 
@@ -1848,7 +1842,6 @@ Interval	Data Available (Open)	Data Available (All)
             var interval = _useSandbox ? 1000 : 500;
 
             // Tradier limits, per minute and per access token (https://docs.tradier.com/docs/rate-limiting):
-            // trading 60, standard and market data 120 in production and 60 in sandbox. We stay about 10% below them
             var requestsPerMinute = _useSandbox ? 55 : 110;
             _rateLimitNextRequest = new Dictionary<TradierApiRequestType, RateGate>
             {

--- a/QuantConnect.TradierBrokerage/TradierBrokerage.cs
+++ b/QuantConnect.TradierBrokerage/TradierBrokerage.cs
@@ -1848,12 +1848,13 @@ Interval	Data Available (Open)	Data Available (All)
             var interval = _useSandbox ? 1000 : 500;
 
             // Tradier limits, per minute and per access token (https://docs.tradier.com/docs/rate-limiting):
-            var requestsPerMinute = _useSandbox ? 60 : 120;
+            // trading 60, standard and market data 120 in production and 60 in sandbox. We stay about 10% below them
+            var requestsPerMinute = _useSandbox ? 55 : 110;
             _rateLimitNextRequest = new Dictionary<TradierApiRequestType, RateGate>
             {
                 { TradierApiRequestType.Data, new RateGate(requestsPerMinute, TimeSpan.FromMinutes(1))},
                 { TradierApiRequestType.Standard, new RateGate(requestsPerMinute, TimeSpan.FromMinutes(1))},
-                { TradierApiRequestType.Orders, new RateGate(60, TimeSpan.FromMinutes(1))},
+                { TradierApiRequestType.Orders, new RateGate(55, TimeSpan.FromMinutes(1))},
             };
 
             _orderFillTimer = new Timer(state => CheckForFills(), null, interval, interval);


### PR DESCRIPTION
#### Description
`TradierBrokerage.Execute` took `_lockAccessCredentials` for the whole call: the rate gate wait, the HTTP request, and every retry including the 3 s sleep between attempts. While one request was retrying, every other order, cancel, update and account request waited on that lock.

This PR:
- Removes the lock. It came from the 2014 daily token refresh flow, which QuantConnect/Lean#5265 removed. The only shared state left under it was `_previousResponseRaw`. That field is replaced by an `Execute` overload with an `out string rawContent` parameter, which `PlaceOrder` uses to build the order error message.
- Turns the retry recursion into a loop.
- Rate gates: trading 55 per minute; standard and market data 110 per minute in production, 55 in sandbox. Tradier documents 60 and 120 (https://docs.tradier.com/docs/rate-limiting); we stay about 10% below to avoid 429s. A burst goes out at once instead of one request per second.

Not in this PR: reading the `X-Ratelimit-*` response headers, a request timeout on the rest client, and the retry policy for order POSTs.

#### Related Issue
Closes #56

#### Motivation and Context
On a live deployment Tradier returned HTTP 500 on order placement. Seven market orders placed within 30 seconds went out one at a time: the first took about 5 minutes, the second another 5.5 minutes, and orders 3 to 6 were accepted 13 to 15 minutes after the algorithm placed them.

#### Requires Documentation Change
No

#### How Has This Been Tested?
- `DoesNotBlockOtherRequestsWhileRetrying`: mock rest client. An order request gets a 500 and sleeps before its retry; an account request started meanwhile must finish within 1 s. Fails on master, passes with this PR.
- `DoesNotBlockOtherRequestsWhileRetryingLive` (Explicit): same scenario against the Tradier sandbox. A path Tradier rejects triggers the retry sleep, `GetCashBalance` is the account request. Fails on master, passes with this PR in 5 s.
- `PlacesOrderBurstWithinTradingRateLimit` (Explicit): 100 limit orders sent at once to the sandbox through `PlaceOrder`, one symbol each at half the last price, then cancelled. Both runs: no 429, 100 distinct broker ids, Tradier showed all 100 open, all 100 cancelled.
  - With this PR: request 60 returned at 9.3 s, request 61 at 60.9 s, all 100 placed in 67 s, cancels done at 3 min 4 s.
  - On master: request 60 at 2 min 8 s, all 100 placed in 2 min 49 s, cancels done at 5 min 26 s. Every request waits for the lock and the one-per-second gate, and the fill poller competes for the same lock.
- All 31 tests in `TradierBrokerageAditionalTests` pass, including the existing `Execute` retry tests.

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`
